### PR TITLE
Pass the column names for get_contour from the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Start memcache server with `sudo /etc/init.d/memcached restart`.
 Run with
 
     $ nix-shell --pure
-    [nix-shell]$ export MEMCACHIER_SERVERS="127.0.0.1:11211"
-    [nix-shell]$ export MEMCACHIER_USERNAME="user"
-    [nix-shell]$ export MEMCACHIER_PASSWORD="password"
     [nix-shell]$ uvicorn main:app --reload
 
 Test the Python modules with

--- a/main.py
+++ b/main.py
@@ -149,6 +149,7 @@ async def get_contour(
     """
 
     # memcached_client().flush_all()
+
     def to_string(dataframe):
         string_ = io.StringIO()
         dataframe.to_csv(string_, index=False)

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ from typing import List
 from fastapi import FastAPI, Query
 import requests
 from toolz.curried import curry, get, compose, memoize, identity, pipe
-from toolz.curried import filter as filter_
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import StreamingResponse
 from pydantic import BaseModel, UrlStr
@@ -144,30 +143,12 @@ async def get_contour(
     contour_value: float = 0.5,
     fill_value: float = 0.0,
     domain: List[float] = Query([-50.0, 50.0]),
+    cols: List[str] = Query(["x", "y", "z"]),
 ):
     """Base endpoint to get a binary csv file and calcuate the zero contour
     """
-    col_names = lambda df, s: pipe(
-        df.columns,
-        filter_(lambda y: s in y),
-        list,
-        lambda x: sorted(x, key=len, reverse=False),
-    )
 
-    cols = sequence(
-        lambda x: x.rename(columns=str.lower),
-        lambda x: x.rename(columns=str.strip),
-        lambda x: x[
-            [
-                col_names(x, "x")[0],
-                col_names(x, "y")[0],
-                (col_names(x, "phi") + col_names(x, "phase") + col_names(x, "field"))[
-                    0
-                ],
-            ]
-        ],
-    )
-
+    # memcached_client().flush_all()
     def to_string(dataframe):
         string_ = io.StringIO()
         dataframe.to_csv(string_, index=False)
@@ -176,7 +157,7 @@ async def get_contour(
     process = sequence(
         io.BytesIO,
         pandas.read_csv,
-        cols,
+        lambda x: x[cols],
         numpy.array,
         calc_contour_vertices(
             domain=domain, fill_value=fill_value, contour_value=contour_value

--- a/shell.nix
+++ b/shell.nix
@@ -38,5 +38,9 @@ in
       export PATH=$PATH:$PYTHONUSERBASE/bin
 
       pip install --user archieml
+
+      export MEMCACHIER_SERVERS="127.0.0.1:11211"
+      export MEMCACHIER_USERNAME="user"
+      export MEMCACHIER_PASSWORD="password"
     '';
   }

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@
 """
 
 from starlette.testclient import TestClient
-from toolz.curried import pipe
+from toolz.curried import pipe, curry
 from main import app
 
 
@@ -13,6 +13,13 @@ def get(url):
     """Get the response given a file URL
     """
     return client.get(f"/get/?url={url}")
+
+
+@curry
+def get_contour(colx, coly, colz, url):
+    """Get the response given a file URL
+    """
+    return client.get(f"/get/?url={url}&cols={colx}&cols={coly}&cols={colz}")
 
 
 def test_csv():
@@ -32,4 +39,14 @@ def test_image():
         "https://drive.google.com/file/d/1b51dmOYwspNVMsaSoED2xUT3pfNq563B/view?usp=sharing",
         get,
         lambda x: x.headers["content-type"] == "image/png",
+    )
+
+
+def test_contour():
+    """Test the get_contour
+    """
+    assert pipe(
+        "https://gist.githubusercontent.com/wd15/7da4626088f0920d0b5bac5727784ef9/raw/6f39388cab76024a48709aa4dcfeccbef68f0f87/phi_fixed.csv",  # pylint: disable=line-too-long
+        get_contour("x", "y", "phi"),
+        lambda x: x.text.partition("\n")[0] == "x,y",
     )


### PR DESCRIPTION
 
 - Put memcache configuration inside nix recipe
 - Pass the columns names for the get_contour endpoint from the frontend
 - Don't infer column names 
 - Add a get_contour test case